### PR TITLE
feat(docs): auto generate the api docs from darcjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,7 @@ darc-docs/.docusaurus
 
 # Idea files
 .idea/
+
+# Darc docs Compiled output
 darc-docs/build
+darc-docs/static/api

--- a/darc-docs/docusaurus.config.js
+++ b/darc-docs/docusaurus.config.js
@@ -77,6 +77,20 @@ const config = {
                         to: '/docs/Overview',
                     },
                     {
+                        type: 'dropdown',
+                        label: 'API',
+                        position: 'left',
+                        items: [
+                            {
+                                label: 'Darcjs API',
+                                href: '/api/darcjs/index.html',
+                                prependBaseUrlToHref: true,
+                                target: '_blank',
+                            },
+                        ],
+                    },
+
+                    {
                         href: 'https://github.com/project-darc/darc',
                         label: 'GitHub',
                         position: 'right',

--- a/darc-docs/package.json
+++ b/darc-docs/package.json
@@ -4,14 +4,18 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
+    "prestart": "npm run generate:darcjs-api",
     "start": "docusaurus start",
+    "prebuild": "npm run generate:darcjs-api",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids"
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "generate:darcjs-api": "typedoc --out ../darc-docs/static/api/darcjs  --entryPointStrategy expand ../darc-js/src --tsconfig ../darc-js/tsconfig.json  --skipErrorChecking",
+    "postinstall": "npm run generate:darcjs-api"
   },
   "dependencies": {
     "@docusaurus/core": "2.4.0",
@@ -26,7 +30,8 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.8.0",
-    "react-use": "^17.4.0"
+    "react-use": "^17.4.0",
+    "typedoc": "^0.24.7"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.4.0"

--- a/darc-docs/pnpm-lock.yaml
+++ b/darc-docs/pnpm-lock.yaml
@@ -40,6 +40,9 @@ dependencies:
   react-use:
     specifier: ^17.4.0
     version: 17.4.0(react-dom@17.0.2)(react@17.0.2)
+  typedoc:
+    specifier: ^0.24.7
+    version: 0.24.7(typescript@5.0.4)
 
 devDependencies:
   '@docusaurus/module-type-aliases':
@@ -3580,6 +3583,10 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /ansi-sequence-parser@1.1.0:
+    resolution: {integrity: sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==}
+    dev: false
+
   /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
@@ -6323,6 +6330,10 @@ packages:
     hasBin: true
     dev: false
 
+  /jsonc-parser@3.2.0:
+    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+    dev: false
+
   /jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
     dependencies:
@@ -6487,6 +6498,10 @@ packages:
       yallist: 4.0.0
     dev: false
 
+  /lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+    dev: false
+
   /magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
@@ -6506,6 +6521,12 @@ packages:
 
   /markdown-escapes@1.0.4:
     resolution: {integrity: sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==}
+    dev: false
+
+  /marked@4.3.0:
+    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
+    engines: {node: '>= 12'}
+    hasBin: true
     dev: false
 
   /mdast-squeeze-paragraphs@4.0.0:
@@ -6643,6 +6664,13 @@ packages:
   /minimatch@5.1.6:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
+
+  /minimatch@9.0.0:
+    resolution: {integrity: sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==}
+    engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
     dev: false
@@ -8382,6 +8410,15 @@ packages:
       rechoir: 0.6.2
     dev: false
 
+  /shiki@0.14.2:
+    resolution: {integrity: sha512-ltSZlSLOuSY0M0Y75KA+ieRaZ0Trf5Wl3gutE7jzLuIcWxLp5i/uEnLoQWNvgKXQ5OMpGkJnVMRLAuzjc0LJ2A==}
+    dependencies:
+      ansi-sequence-parser: 1.1.0
+      jsonc-parser: 3.2.0
+      vscode-oniguruma: 1.7.0
+      vscode-textmate: 8.0.0
+    dev: false
+
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
@@ -8948,6 +8985,20 @@ packages:
       is-typedarray: 1.0.0
     dev: false
 
+  /typedoc@0.24.7(typescript@5.0.4):
+    resolution: {integrity: sha512-zzfKDFIZADA+XRIp2rMzLe9xZ6pt12yQOhCr7cD7/PBTjhPmMyMvGrkZ2lPNJitg3Hj1SeiYFNzCsSDrlpxpKw==}
+    engines: {node: '>= 14.14'}
+    hasBin: true
+    peerDependencies:
+      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x
+    dependencies:
+      lunr: 2.3.9
+      marked: 4.3.0
+      minimatch: 9.0.0
+      shiki: 0.14.2
+      typescript: 5.0.4
+    dev: false
+
   /typescript@5.0.4:
     resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
     engines: {node: '>=12.20'}
@@ -9245,6 +9296,14 @@ packages:
       is-buffer: 2.0.5
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
+    dev: false
+
+  /vscode-oniguruma@1.7.0:
+    resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
+    dev: false
+
+  /vscode-textmate@8.0.0:
+    resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
     dev: false
 
   /wait-on@6.0.1:


### PR DESCRIPTION
Add the pre command `generate:darcjs-api` in npm lifecycle.
This command allows the typedoc auto generate api files

```
"prestart": "npm run generate:darcjs-api",
"prebuild": "npm run generate:darcjs-api",
"postinstall": "npm run generate:darcjs-api"
"generate:darcjs-api": "typedoc --out ../darc-docs/static/api/darcjs  --entryPointStrategy expand ../darc-js/src --tsconfig ../darc-js/tsconfig.json  --skipErrorChecking",
```

<img width="408" alt="image" src="https://user-images.githubusercontent.com/13300332/236783302-b4c05af8-2ffb-4beb-9d72-9eb802d0ca2b.png">

![image](https://user-images.githubusercontent.com/13300332/236783331-3502a3f1-2054-4847-a858-2c676d2d6c1e.png)
