### PR TITLE
Fix typos

### DIFF
--- a/darc-docs/docs/DARC Protocol/Condition Nodes.md
+++ b/darc-docs/docs/DARC Protocol/Condition Nodes.md
@@ -100,7 +100,7 @@ const conditionTree =
 
 ### Boolean Values
 
-There are two boolean values in the DARC protocol: class `TRUE` and clss `FALSE`, or wrapper function `boolean_true()` and `boolean_false()`. They are used to represent a boolean node in the condition tree.
+There are two boolean values in the DARC protocol: class `TRUE` and class `FALSE`, or wrapper function `boolean_true()` and `boolean_false()`. They are used to represent a boolean node in the condition tree.
 
 ### Condition Expression
 

--- a/darc-js/README.md
+++ b/darc-js/README.md
@@ -47,7 +47,7 @@ const darc_contract_address = await darcjs.deployDARC(
   DARC_VERSION.Test, signer
 );
 
-// acceess the deployed DARC via the DARC contract address
+// access the deployed DARC via the DARC contract address
 const myDeployedDARC = new darcjs.DARC({
   address: darc_contract_address,
   wallet: signer,


### PR DESCRIPTION
1. Fix `darc-docs/docs/DARC Protocol/Condition Nodes.md` typo
2. Fix `darc-js/README.md` typo